### PR TITLE
Implement Warehouse USA manual entry API and table

### DIFF
--- a/dist/admins/warehouseUsaPanel.php
+++ b/dist/admins/warehouseUsaPanel.php
@@ -11,7 +11,7 @@ $usuario = new Usuario($conexion);
 $user = $usuario->obtenerUsuarioPorId($IdUsuario);
 
 // Carga manual de Warehouse USA guardada en dispatch
-$queryManual = "SELECT cantidad AS cajas, palets, numero_lote AS lote_produccion, numero_orden_compra AS po, descripcion, numero_factura AS invoice, fecha_entrada AS fecha_ingreso, recibo_almacen AS warehouse_receive FROM dispatch WHERE notas = '' OR notas IS NULL ORDER BY fecha_entrada DESC";
+$queryManual = "SELECT cantidad AS cajas, numero_lote AS lote_produccion, numero_orden_compra AS po, descripcion, numero_factura AS invoice, fecha_entrada AS fecha_ingreso, recibo_almacen AS warehouse_receive FROM dispatch WHERE notas = '' OR notas IS NULL ORDER BY fecha_entrada DESC";
 $manualRes = $conexion->query($queryManual);
 
 ?>
@@ -314,7 +314,6 @@ $manualRes = $conexion->query($queryManual);
                   <thead>
                     <tr>
                       <th>Cajas</th>
-                      <th>Palets</th>
                       <th>Lote</th>
                       <th>PO</th>
                       <th>Descripción</th>
@@ -328,7 +327,6 @@ $manualRes = $conexion->query($queryManual);
                       <?php while($m = $manualRes->fetch_assoc()): ?>
                         <tr>
                           <td><?= htmlspecialchars($m['cajas']) ?></td>
-                          <td><?= htmlspecialchars($m['palets']) ?></td>
                           <td><?= htmlspecialchars($m['lote_produccion']) ?></td>
                           <td><?= htmlspecialchars($m['po']) ?></td>
                           <td><?= htmlspecialchars($m['descripcion']) ?></td>

--- a/dist/admins/warehouseUsaPanel.php
+++ b/dist/admins/warehouseUsaPanel.php
@@ -816,8 +816,3 @@ $manualRes = $conexion->query($queryManual);
 <!-- [Body] end -->
 
 </html>
-
-<?php
-
-
-?>

--- a/dist/admins/warehouseUsaPanel.php
+++ b/dist/admins/warehouseUsaPanel.php
@@ -11,7 +11,7 @@ $usuario = new Usuario($conexion);
 $user = $usuario->obtenerUsuarioPorId($IdUsuario);
 
 // Carga manual de Warehouse USA guardada en dispatch
-$queryManual = "SELECT cantidad AS cajas, numero_lote AS lote_produccion, numero_orden_compra AS po, descripcion, numero_factura AS invoice, fecha_entrada AS fecha_ingreso, recibo_almacen AS warehouse_receive FROM dispatch WHERE notas = '' OR notas IS NULL ORDER BY fecha_entrada DESC";
+$queryManual = "SELECT cantidad AS cajas, notas AS palets, numero_lote AS lote_produccion, numero_orden_compra AS po, descripcion, numero_factura AS invoice, fecha_entrada AS fecha_ingreso, recibo_almacen AS warehouse_receive FROM dispatch ORDER BY fecha_entrada DESC";
 $manualRes = $conexion->query($queryManual);
 
 ?>
@@ -314,6 +314,7 @@ $manualRes = $conexion->query($queryManual);
                   <thead>
                     <tr>
                       <th>Cajas</th>
+                      <th>Palets</th>
                       <th>Lote</th>
                       <th>PO</th>
                       <th>Descripción</th>
@@ -327,6 +328,7 @@ $manualRes = $conexion->query($queryManual);
                       <?php while($m = $manualRes->fetch_assoc()): ?>
                         <tr>
                           <td><?= htmlspecialchars($m['cajas']) ?></td>
+                          <td><?= htmlspecialchars($m['palets']) ?></td>
                           <td><?= htmlspecialchars($m['lote_produccion']) ?></td>
                           <td><?= htmlspecialchars($m['po']) ?></td>
                           <td><?= htmlspecialchars($m['descripcion']) ?></td>

--- a/dist/admins/warehouseUsaPanel.php
+++ b/dist/admins/warehouseUsaPanel.php
@@ -349,11 +349,13 @@ $manualRes = $conexion->query($queryManual);
       <div class="row">
         <div class="col-12">
           <div class="card table-card mb-4 mx-auto">
-            <div class="card-header"><h5>Carga Manual Warehouse USA</h5></div>
-            <div class="card-body">
-              <div class="d-flex justify-content-end mb-3">
-                <a class="text-white" href="../application/crearWarehouseUsa.php"><button type="button" class="btn btn-success text-white me-3">Cargar nuevo Warehouse USA</button></a>
+            <div class="card-header">
+              <div class="d-flex justify-content-end">
+                <a class="text-white" href="../application/crearWarehouseUsa.php"><button type="button" class="btn btn-success text-white me-2">Cargar nuevo Warehouse USA</button></a>
               </div>
+            </div>
+            <div class="card-body">
+              
               <div class="table-responsive">
                 <table class="table table-sm" id="pc-dt-simple">
                   <thead>

--- a/dist/admins/warehouseUsaPanel.php
+++ b/dist/admins/warehouseUsaPanel.php
@@ -10,8 +10,8 @@ $usuario = new Usuario($conexion);
 
 $user = $usuario->obtenerUsuarioPorId($IdUsuario);
 
-// Carga manual de Warehouse USA
-$queryManual = "SELECT cajas, palets, lote_produccion, po, descripcion, invoice, fecha_ingreso, warehouse_receive FROM warehouse_usa_manual ORDER BY fecha_ingreso DESC";
+// Carga manual de Warehouse USA guardada en dispatch
+$queryManual = "SELECT cantidad AS cajas, palets, numero_lote AS lote_produccion, numero_orden_compra AS po, descripcion, numero_factura AS invoice, fecha_entrada AS fecha_ingreso, recibo_almacen AS warehouse_receive FROM dispatch WHERE notas = '' OR notas IS NULL ORDER BY fecha_entrada DESC";
 $manualRes = $conexion->query($queryManual);
 
 ?>

--- a/dist/admins/warehouseUsaPanel.php
+++ b/dist/admins/warehouseUsaPanel.php
@@ -10,6 +10,10 @@ $usuario = new Usuario($conexion);
 
 $user = $usuario->obtenerUsuarioPorId($IdUsuario);
 
+// Carga manual de Warehouse USA
+$queryManual = "SELECT cajas, palets, lote_produccion, po, descripcion, invoice, fecha_ingreso, warehouse_receive FROM warehouse_usa_manual ORDER BY fecha_ingreso DESC";
+$manualRes = $conexion->query($queryManual);
+
 ?>
 
 <!DOCTYPE html>
@@ -302,6 +306,45 @@ $user = $usuario->obtenerUsuarioPorId($IdUsuario);
       <!-- [ Main Content ] start -->
       <div class="row">
         <div class="col-12">
+          <div class="card table-card mb-4">
+            <div class="card-header"><h5>Carga Manual Warehouse USA</h5></div>
+            <div class="card-body">
+              <div class="table-responsive">
+                <table class="table table-sm">
+                  <thead>
+                    <tr>
+                      <th>Cajas</th>
+                      <th>Palets</th>
+                      <th>Lote</th>
+                      <th>PO</th>
+                      <th>Descripción</th>
+                      <th>Invoice</th>
+                      <th>Fecha Ingreso</th>
+                      <th>Warehouse Receive</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <?php if($manualRes && $manualRes->num_rows > 0): ?>
+                      <?php while($m = $manualRes->fetch_assoc()): ?>
+                        <tr>
+                          <td><?= htmlspecialchars($m['cajas']) ?></td>
+                          <td><?= htmlspecialchars($m['palets']) ?></td>
+                          <td><?= htmlspecialchars($m['lote_produccion']) ?></td>
+                          <td><?= htmlspecialchars($m['po']) ?></td>
+                          <td><?= htmlspecialchars($m['descripcion']) ?></td>
+                          <td><?= htmlspecialchars($m['invoice']) ?></td>
+                          <td><?= htmlspecialchars($m['fecha_ingreso']) ?></td>
+                          <td><?= htmlspecialchars($m['warehouse_receive']) ?></td>
+                        </tr>
+                      <?php endwhile; else: ?>
+                        <tr><td colspan="8" class="text-center">Sin registros</td></tr>
+                    <?php endif; ?>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
           <div class="card table-card">
             <div class="card-body pt-3">
               <div class="d-flex justify-content-end mb-3">

--- a/dist/admins/warehouseUsaPanel.php
+++ b/dist/admins/warehouseUsaPanel.php
@@ -309,8 +309,11 @@ $manualRes = $conexion->query($queryManual);
           <div class="card table-card mb-4">
             <div class="card-header"><h5>Carga Manual Warehouse USA</h5></div>
             <div class="card-body">
+              <div class="d-flex justify-content-end mb-3">
+                <a class="text-white" href="../application/crearWarehouseUsa.php"><button type="button" class="btn btn-success text-white me-3">Cargar nuevo Warehouse USA</button></a>
+              </div>
               <div class="table-responsive">
-                <table class="table table-sm">
+                <table class="table table-sm" id="pc-dt-simple">
                   <thead>
                     <tr>
                       <th>Cajas</th>
@@ -345,104 +348,6 @@ $manualRes = $conexion->query($queryManual);
             </div>
           </div>
 
-          <div class="card table-card">
-            <div class="card-body pt-3">
-              <div class="d-flex justify-content-end mb-3">
-                <a class="text-white" href="../application/crearWarehouseUsa.php"><button type="button" class="btn btn-success text-white me-3">Cargar nuevo Warehouse USA</button></a>
-              </div>
-              <div class="table-responsive">
-                <table class="table table-hover">
-                  <thead>
-                    <tr>
-                     <th>Fecha Entrada</th>
-      <th>Fecha de salida</th>
-      <th>Recibo de Almacén</th>
-      <th>Estado</th>
-      <th>Número de Factura</th>
-      <th>Número de Lote</th>
-      <th>Notas</th>
-      <th>Número de Orden de Compra</th>
-      <th>Número de Parte</th>
-      <th>Descripción</th>
-      <th>Modelo</th>
-      <th>Cantidad</th>
-      <th>Valor Unitario</th>
-      <th>Valor</th>
-      <th>Unidad</th>
-      <th>Longitud (in)</th>
-      <th>Ancho (in)</th>
-      <th>Altura (in)</th>
-      <th>Peso (lb)</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <?php
-                    $query = "SELECT ImportsID, Booking_BK, Number_Commercial_Invoice, status, creation_date 
-          FROM imports 
-          WHERE status != 2 
-          ORDER BY creation_date";
-                    $result = $conexion->query($query);
-
-                    // Verificar error en consulta
-                    if (!$result) {
-                      die("Error en la consulta: " . $conexion->error);
-                    }
-
-                    // Verificar si hay registros
-                    if (1==2) { // $result->num_rows > 0
-                      while ($row = $result->fetch_assoc()) {
-                        $fechaOriginal = $row['creation_date'];
-                        $fecha = date('d/m/Y', strtotime($fechaOriginal));
-                        $hora  = date('h:i A', strtotime($fechaOriginal));
-                    ?>
-                        <tr>
-                          <td><?= htmlspecialchars($row['Booking_BK']) ?></td>
-                          <td><?= htmlspecialchars($row['Number_Commercial_Invoice']) ?></td>
-                          <td><?= $fecha ?> <span class="text-muted text-sm d-block"><?= $hora ?></span></td>
-                          <td>
-                            <select
-                              class="badge-select badge"
-                              data-export-id="<?= $row['ImportsID'] ?>"
-                              style="appearance:none; width:70%; margin-left:-15%">
-                              <?php
-                              $queryselect  = "SELECT IdEstados, nombre FROM estadosliquidacion";
-                              $resultselect = $conexion->query($queryselect);
-                              while ($row2 = $resultselect->fetch_assoc()) {
-                                if ($row2['IdEstados'] == 4) continue;
-                                $isSel = ($row['status'] == $row2['IdEstados']) ? ' selected' : '';
-                              ?>
-                                <option value="<?= $row2['IdEstados'] ?>" <?= $isSel ?>>
-                                  <?= $row2['nombre'] ?>
-                                </option>
-                              <?php } ?>
-                            </select>
-                          </td>
-                          <td>
-                            <a href="../application/detalleLiquidacionImport.php?ImportID=<?= $row["ImportsID"] ?>" class="text-primary me-2">
-                              <i class="ti ti-eye"></i>
-                            </a>
-                            <?php
-                            $isDisabled = ($row['status'] == 3);
-                            $href = $isDisabled ? '' : 'href="../application/editarLiquidacionImport.php?ImportID=' . $row["ImportsID"] . '"';
-                            $classes = 'text-warning me-2' . ($isDisabled ? ' disabled text-muted' : '');
-                            ?>
-                            <a <?= $href ?> class="<?= $classes ?>" <?= $isDisabled ? 'aria-disabled="true" tabindex="-1"' : '' ?>>
-                              <i class="ti ti-edit"></i>
-                            </a>
-                          </td>
-                        </tr>
-                    <?php
-                      }
-                    } else {
-                      echo "<tr><td colspan='5' class='text-center'>No hay registros disponibles.</td></tr>";
-                    }
-                    ?> */
-                  </tbody>
-
-                </table>
-              </div>
-            </div>
-          </div>
         </div>
 
 

--- a/dist/admins/warehouseUsaPanel.php
+++ b/dist/admins/warehouseUsaPanel.php
@@ -78,6 +78,39 @@ $manualRes = $conexion->query($queryManual);
     .badge-select.total {
       background-color: #198754 !important;
     }
+
+    .table-responsive {
+      position: relative;
+      padding-bottom: 3.5rem;
+    }
+
+    .table-responsive .pagination-wrapper {
+      position: absolute;
+      bottom: 0.5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #fff;
+      padding: 0.25rem 0;
+      z-index: 10;
+    }
+
+    .table-responsive .pagination-wrapper .pagination {
+      margin: 0;
+    }
+
+    .table-responsive .pagination-wrapper .pagination li.page-item {
+      margin: 0 0.125rem;
+    }
+
+    .table-responsive .pagination-wrapper .pagination li.page-item .page-link {
+      padding: 0.375rem 0.75rem;
+    }
+
+    .table-responsive .pagination-wrapper .pagination li.active .page-link {
+      background-color: #0d6efd;
+      border-color: #0d6efd;
+      color: #fff;
+    }
   </style>
 
 </head>
@@ -315,7 +348,7 @@ $manualRes = $conexion->query($queryManual);
       <!-- [ Main Content ] start -->
       <div class="row">
         <div class="col-12">
-          <div class="card table-card mb-4">
+          <div class="card table-card mb-4 mx-auto">
             <div class="card-header"><h5>Carga Manual Warehouse USA</h5></div>
             <div class="card-body">
               <div class="d-flex justify-content-end mb-3">

--- a/dist/admins/warehouseUsaPanel.php
+++ b/dist/admins/warehouseUsaPanel.php
@@ -32,6 +32,15 @@ $manualRes = $conexion->query($queryManual);
   <meta name="author" content="phoenixcoded" />
 
   <!-- [Favicon] icon -->
+  <link rel="icon" href="../assets/images/ekologistic.png" type="image/x-icon" />
+
+  <!-- jQuery (DataTables lo necesita) -->
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <!-- DataTables CSS y JS -->
+  <link href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css" rel="stylesheet" />
+  <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/dataTables.bootstrap5.min.css" />
+  <script src="https://cdn.datatables.net/1.13.4/js/dataTables.bootstrap5.min.js"></script>
 
   <link rel="stylesheet" href="../assets/css/plugins/style.css">
   <!-- [Google Font : Public Sans] icon -->
@@ -549,11 +558,28 @@ $manualRes = $conexion->query($queryManual);
     preset_change("preset-1");
   </script>
 
-  <script type="module">
-    import {
-      DataTable
-    } from "../assets/js/plugins/module.js"
-    window.dt = new DataTable("#pc-dt-simple");
+  <script>
+    var dt;
+    const dtConfig = {
+      paging: true,
+      pageLength: 10,
+      pagingType: 'simple_numbers',
+      language: { paginate: { previous: '«', next: '»' } },
+      lengthChange: false,
+      searching: false,
+      info: false,
+      ordering: false,
+      dom: 't<"pagination-wrapper"p>'
+    };
+
+    function initDataTable() {
+      dt = $('#pc-dt-simple').DataTable(dtConfig);
+      $('.pagination-wrapper').appendTo($('#pc-dt-simple').closest('.table-responsive'));
+    }
+
+    $(document).ready(() => {
+      initDataTable();
+    });
   </script>
   <div class="offcanvas border-0 pct-offcanvas offcanvas-end" tabindex="-1" id="offcanvas_pc_layout">
     <div class="offcanvas-header justify-content-between">

--- a/dist/api/warehouseusa/guardar_manual.php
+++ b/dist/api/warehouseusa/guardar_manual.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include '../con_db.php';
+include '../../con_db.php';
 header('Content-Type: application/json');
 
 try {

--- a/dist/api/warehouseusa/guardar_manual.php
+++ b/dist/api/warehouseusa/guardar_manual.php
@@ -9,27 +9,79 @@ try {
     }
 
     $data = json_decode(file_get_contents('php://input'), true);
-    $cajas    = intval($data['cajas']    ?? 0);
-    $palets   = intval($data['palets']   ?? 0);
-    $lote     = trim($data['lote']       ?? '');
-    $po       = trim($data['po']         ?? '');
-    $desc     = trim($data['descripcion']?? '');
-    $invoice  = trim($data['invoice']    ?? '');
-    $fecha    = trim($data['fecha_ingreso'] ?? '');
-    $receive  = trim($data['warehouse_receive'] ?? '');
+    $fechaEntrada = trim($data['fecha_entrada'] ?? '');
+    $fechaSalida  = trim($data['fecha_salida'] ?? '');
+    $recibo       = trim($data['recibo_almacen'] ?? '');
+    $estado       = trim($data['estado'] ?? '');
+    $numeroFactura= trim($data['numero_factura'] ?? '');
+    $numeroLote   = trim($data['numero_lote'] ?? '');
+    $notas        = trim($data['notas'] ?? '');
+    $ordenCompra  = trim($data['orden_compra'] ?? '');
+    $numeroParte  = trim($data['numero_parte'] ?? '');
+    $descripcion  = trim($data['descripcion'] ?? '');
+    $modelo       = trim($data['modelo'] ?? '');
+    $cantidad     = intval($data['cantidad'] ?? 0);
+    $valorUnit    = $data['valor_unitario'] === '' ? null : floatval(str_replace(',', '.', $data['valor_unitario']));
+    $valor        = $data['valor'] === '' ? null : floatval(str_replace(',', '.', $data['valor']));
+    $unidad       = trim($data['unidad'] ?? '');
+    $longitudIn   = $data['longitud'] === '' ? null : floatval(str_replace(',', '.', $data['longitud']));
+    $anchoIn      = $data['ancho'] === '' ? null : floatval(str_replace(',', '.', $data['ancho']));
+    $alturaIn     = $data['altura'] === '' ? null : floatval(str_replace(',', '.', $data['altura']));
+    $pesoLb       = $data['peso'] === '' ? null : floatval(str_replace(',', '.', $data['peso']));
 
-    if ($invoice === '' || $fecha === '') {
+    if ($numeroFactura === '' || $fechaEntrada === '') {
         echo json_encode(['success' => false, 'message' => 'Datos incompletos']);
         exit;
     }
 
     $stmt = $conexion->prepare(
-        "INSERT INTO dispatch (cantidad, palets, numero_lote, numero_orden_compra, descripcion, numero_factura, fecha_entrada, recibo_almacen, estado) VALUES (?,?,?,?,?,?,?,?, 'Cargado')"
+        "INSERT INTO dispatch (
+            fecha_entrada,
+            fecha_salida,
+            recibo_almacen,
+            estado,
+            numero_factura,
+            numero_lote,
+            notas,
+            numero_orden_compra,
+            numero_parte,
+            descripcion,
+            modelo,
+            cantidad,
+            valor_unitario,
+            valor,
+            unidad,
+            longitud_in,
+            ancho_in,
+            altura_in,
+            peso_lb
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
     );
     if (!$stmt) {
         throw new Exception('Error en prepare: ' . $conexion->error);
     }
-    $stmt->bind_param('iissssss', $cajas, $palets, $lote, $po, $desc, $invoice, $fecha, $receive);
+    $stmt->bind_param(
+        'ssssiisisssiddsdddd',
+        $fechaEntrada,
+        $fechaSalida,
+        $recibo,
+        $estado,
+        $numeroFactura,
+        $numeroLote,
+        $notas,
+        $ordenCompra,
+        $numeroParte,
+        $descripcion,
+        $modelo,
+        $cantidad,
+        $valorUnit,
+        $valor,
+        $unidad,
+        $longitudIn,
+        $anchoIn,
+        $alturaIn,
+        $pesoLb
+    );
     $stmt->execute();
     $stmt->close();
 

--- a/dist/api/warehouseusa/guardar_manual.php
+++ b/dist/api/warehouseusa/guardar_manual.php
@@ -24,7 +24,7 @@ try {
     }
 
     $stmt = $conexion->prepare(
-        "INSERT INTO warehouse_usa_manual (cajas, palets, lote_produccion, po, descripcion, invoice, fecha_ingreso, warehouse_receive) VALUES (?,?,?,?,?,?,?,?)"
+        "INSERT INTO dispatch (cantidad, palets, numero_lote, numero_orden_compra, descripcion, numero_factura, fecha_entrada, recibo_almacen, estado) VALUES (?,?,?,?,?,?,?,?, 'Cargado')"
     );
     if (!$stmt) {
         throw new Exception('Error en prepare: ' . $conexion->error);

--- a/dist/api/warehouseusa/guardar_manual.php
+++ b/dist/api/warehouseusa/guardar_manual.php
@@ -1,0 +1,42 @@
+<?php
+session_start();
+include '../con_db.php';
+header('Content-Type: application/json');
+
+try {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        throw new Exception('Método no permitido', 405);
+    }
+
+    $data = json_decode(file_get_contents('php://input'), true);
+    $cajas    = intval($data['cajas']    ?? 0);
+    $palets   = intval($data['palets']   ?? 0);
+    $lote     = trim($data['lote']       ?? '');
+    $po       = trim($data['po']         ?? '');
+    $desc     = trim($data['descripcion']?? '');
+    $invoice  = trim($data['invoice']    ?? '');
+    $fecha    = trim($data['fecha_ingreso'] ?? '');
+    $receive  = trim($data['warehouse_receive'] ?? '');
+
+    if ($invoice === '' || $fecha === '') {
+        echo json_encode(['success' => false, 'message' => 'Datos incompletos']);
+        exit;
+    }
+
+    $stmt = $conexion->prepare(
+        "INSERT INTO warehouse_usa_manual (cajas, palets, lote_produccion, po, descripcion, invoice, fecha_ingreso, warehouse_receive) VALUES (?,?,?,?,?,?,?,?)"
+    );
+    if (!$stmt) {
+        throw new Exception('Error en prepare: ' . $conexion->error);
+    }
+    $stmt->bind_param('iissssss', $cajas, $palets, $lote, $po, $desc, $invoice, $fecha, $receive);
+    $stmt->execute();
+    $stmt->close();
+
+    echo json_encode(['success' => true, 'id' => $conexion->insert_id]);
+
+} catch (Exception $e) {
+    http_response_code($e->getCode() ?: 500);
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}
+?>

--- a/dist/api/warehouseusa/guardar_manual.php
+++ b/dist/api/warehouseusa/guardar_manual.php
@@ -15,7 +15,7 @@ try {
     $estado       = trim($data['estado'] ?? '');
     $numeroFactura= trim($data['numero_factura'] ?? '');
     $numeroLote   = trim($data['numero_lote'] ?? '');
-    $notas        = trim($data['notas'] ?? '');
+    $palets       = trim($data['palets'] ?? '');
     $ordenCompra  = trim($data['orden_compra'] ?? '');
     $numeroParte  = trim($data['numero_parte'] ?? '');
     $descripcion  = trim($data['descripcion'] ?? '');
@@ -68,7 +68,7 @@ try {
         $estado,
         $numeroFactura,
         $numeroLote,
-        $notas,
+        $palets,
         $ordenCompra,
         $numeroParte,
         $descripcion,

--- a/dist/application/crearWarehouseUsa.php
+++ b/dist/application/crearWarehouseUsa.php
@@ -358,6 +358,14 @@ $user=$usuario->obtenerUsuarioPorId($IdUsuario);
         <label class="form-label">Peso (lb)</label>
         <input type="number" name="peso" step="0.01" class="form-control">
       </div>
+      <div class="col-md-4">
+        <label class="form-label">Cantidad de Cajas</label>
+        <input type="number" name="cantidad_cajas" class="form-control">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Cantidad de Palets</label>
+        <input type="number" name="cantidad_palets" class="form-control">
+      </div>
     </div>
 
     <div class="mt-4 d-flex justify-content-between">
@@ -476,67 +484,36 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-  const bookingEl   = document.getElementById('bookingSelect');
-  const invoiceEl   = document.getElementById('invoiceSelect');
-  const selectEl    = document.getElementById('incotermSelect');
-  const btnGuardar  = document.querySelector('.btn-success');
+  const form = document.querySelector('form[action="guardar_warehouse.php"]');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = {
+      cajas: parseInt(form.cantidad_cajas.value) || 0,
+      palets: parseInt(form.cantidad_palets.value) || 0,
+      lote: form.numero_lote.value.trim(),
+      po: form.orden_compra.value.trim(),
+      descripcion: form.descripcion.value.trim(),
+      invoice: form.numero_factura.value.trim(),
+      fecha_ingreso: form.fecha_entrada.value,
+      warehouse_receive: form.recibo_almacen.value.trim()
+    };
 
-  btnGuardar.addEventListener('click', () => {
-    const booking    = bookingEl.value.trim();
-    const invoice    = invoiceEl.value.trim();
-    const incotermId = selectEl.value;
-
-    if (!booking || !invoice || !incotermId) {
-      return Swal.fire({
-        icon: 'warning',
-        title: 'Faltan datos',
-        text: 'Completa Booking, Invoice e Incoterm antes de guardar.'
-      });
-    }
-
-    const bloque = document.querySelector(`.incoterm-item[data-incoterm="${incotermId}"]`);
-    if (!bloque) return;
-
-    const items = [];
-    bloque.querySelectorAll('tbody tr').forEach(tr => {
-      const itemId      = parseInt(tr.dataset.itemId, 10);
-      const descripcion = tr.children[0].textContent.trim();
-
-      // Cantidad y valor unitario
-      const rawCant = tr.querySelector('.cantidad').value;
-      const rawVU   = tr.querySelector('.valor-unitario').value;
-
-      // Convertimos formatos con coma decimal a punto decimal
-      const cantidad      = rawCant === '' ? null : parseFloat(rawCant.replace(',', '.')) || 0;
-      const valorUnitario = rawVU   === '' ? null : parseFloat(rawVU.replace(',', '.')) || 0;
-      const valorTotal    = (cantidad || 0) * (valorUnitario || 0);
-
-      items.push({
-        incotermId,
-        itemId,
-        descripcion,
-        cantidad,
-        valorUnitario,
-        valorTotal
-      });
-    });
-
-    fetch('../api/despacho/guardarliquidaciondespacho.php', {
+    fetch('../api/warehouseusa/guardar_manual.php', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ booking, invoice, items })
+      body: JSON.stringify(data)
     })
     .then(r => r.json())
     .then(resp => {
       if (resp.success) {
-        Swal.fire({ icon: 'success', title: '¡Guardado!', text: 'Correcto.' })
-          .then(() => location.reload());
+        Swal.fire({ icon: 'success', title: 'Guardado', text: 'Registro creado' })
+          .then(() => location.href = '../admins/warehouseUsaPanel.php');
       } else {
-        Swal.fire({ icon: 'error', title: 'Error', text: resp.message });
+        Swal.fire({ icon: 'error', title: 'Error', text: resp.message || 'Error' });
       }
     })
     .catch(() => {
-      Swal.fire({ icon: 'error', title: 'Error', text: 'Error del servidor.' });
+      Swal.fire({ icon: 'error', title: 'Error', text: 'Error de servidor' });
     });
   });
 });

--- a/dist/application/crearWarehouseUsa.php
+++ b/dist/application/crearWarehouseUsa.php
@@ -358,14 +358,6 @@ $user=$usuario->obtenerUsuarioPorId($IdUsuario);
         <label class="form-label">Peso (lb)</label>
         <input type="number" name="peso" step="0.01" class="form-control">
       </div>
-      <div class="col-md-4">
-        <label class="form-label">Cantidad de Cajas</label>
-        <input type="number" name="cantidad_cajas" class="form-control">
-      </div>
-      <div class="col-md-4">
-        <label class="form-label">Cantidad de Palets</label>
-        <input type="number" name="cantidad_palets" class="form-control">
-      </div>
     </div>
 
     <div class="mt-4 d-flex justify-content-between">
@@ -488,14 +480,25 @@ document.addEventListener('DOMContentLoaded', () => {
   form.addEventListener('submit', e => {
     e.preventDefault();
     const data = {
-      cajas: parseInt(form.cantidad_cajas.value) || 0,
-      palets: parseInt(form.cantidad_palets.value) || 0,
-      lote: form.numero_lote.value.trim(),
-      po: form.orden_compra.value.trim(),
+      fecha_entrada: form.fecha_entrada.value,
+      fecha_salida: form.fecha_salida.value,
+      recibo_almacen: form.recibo_almacen.value.trim(),
+      estado: form.estado.value.trim(),
+      numero_factura: form.numero_factura.value.trim(),
+      numero_lote: form.numero_lote.value.trim(),
+      notas: form.notas.value.trim(),
+      orden_compra: form.orden_compra.value.trim(),
+      numero_parte: form.numero_parte.value.trim(),
       descripcion: form.descripcion.value.trim(),
-      invoice: form.numero_factura.value.trim(),
-      fecha_ingreso: form.fecha_entrada.value,
-      warehouse_receive: form.recibo_almacen.value.trim()
+      modelo: form.modelo.value.trim(),
+      cantidad: parseInt(form.cantidad.value) || 0,
+      valor_unitario: form.valor_unitario.value.trim(),
+      valor: form.valor.value.trim(),
+      unidad: form.unidad.value.trim(),
+      longitud: form.longitud.value,
+      ancho: form.ancho.value,
+      altura: form.altura.value,
+      peso: form.peso.value
     };
 
     fetch('../api/warehouseusa/guardar_manual.php', {

--- a/dist/application/crearWarehouseUsa.php
+++ b/dist/application/crearWarehouseUsa.php
@@ -279,7 +279,7 @@ $user=$usuario->obtenerUsuarioPorId($IdUsuario);
 
 <div class="container mt-5">
   <div class="card shadow-sm">
-    <form method="POST" action="guardar_warehouse.php">
+    <form method="POST" action="#">
   <div class="card-body">
     <div class="row g-3">
       <div class="col-md-4">
@@ -307,8 +307,8 @@ $user=$usuario->obtenerUsuarioPorId($IdUsuario);
         <input type="text" name="numero_lote" class="form-control">
       </div>
       <div class="col-md-4">
-        <label class="form-label">Notas</label>
-        <input type="text" name="notas" class="form-control">
+        <label class="form-label">Palets</label>
+        <input type="number" name="palets" class="form-control">
       </div>
       <div class="col-md-4">
         <label class="form-label">Número de Orden de Compra</label>
@@ -476,7 +476,7 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-  const form = document.querySelector('form[action="guardar_warehouse.php"]');
+  const form = document.querySelector('form[action="#"]');
   form.addEventListener('submit', e => {
     e.preventDefault();
     const data = {
@@ -486,7 +486,7 @@ document.addEventListener('DOMContentLoaded', () => {
       estado: form.estado.value.trim(),
       numero_factura: form.numero_factura.value.trim(),
       numero_lote: form.numero_lote.value.trim(),
-      notas: form.notas.value.trim(),
+      palets: form.palets.value.trim(),
       orden_compra: form.orden_compra.value.trim(),
       numero_parte: form.numero_parte.value.trim(),
       descripcion: form.descripcion.value.trim(),

--- a/dist/application/crearWarehouseUsa.php
+++ b/dist/application/crearWarehouseUsa.php
@@ -278,7 +278,7 @@ $user=$usuario->obtenerUsuarioPorId($IdUsuario);
 <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">
 
 <div class="container mt-5">
-  <div class="card shadow-sm">
+  <div class="card shadow-sm mx-auto" style="max-width: 900px;">
     <form method="POST" action="#">
   <div class="card-body">
     <div class="row g-3">

--- a/dist/application/crearWarehouseUsa.php
+++ b/dist/application/crearWarehouseUsa.php
@@ -744,8 +744,3 @@ document.addEventListener('DOMContentLoaded', () => {
   </body>
   <!-- [Body] end -->
 </html>
-
-
-<?php
-
-?>


### PR DESCRIPTION
## Summary
- add API to store manual Warehouse USA entries
- allow creating manual entries via `crearWarehouseUsa.php`
- show manual entries in `warehouseUsaPanel.php`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861f12220088326adfffe44a3be7c64