### PR TITLE
Add remaining pallets and boxes

### DIFF
--- a/dist/api/warehouseusa/actualizar_manual.php
+++ b/dist/api/warehouseusa/actualizar_manual.php
@@ -19,10 +19,12 @@ try {
     $numeroCont     = trim($data['numero_contenedor'] ?? '');
     $ordenCompra    = trim($data['orden_compra'] ?? '');
     $palets         = trim($data['palets'] ?? '');
+    $paletsR        = trim($data['palets_restante'] ?? '');
     $numeroParte    = trim($data['numero_parte'] ?? '');
     $descripcion    = trim($data['descripcion'] ?? '');
     $modelo         = trim($data['modelo'] ?? '');
     $cantidad       = intval($data['cantidad'] ?? 0);
+    $cantidadR      = intval($data['cantidad_restante'] ?? 0);
     $valorUnit      = $data['valor_unitario'] === '' ? null : floatval(str_replace(',', '.', $data['valor_unitario']));
     $valor          = $data['valor'] === '' ? null : floatval(str_replace(',', '.', $data['valor']));
     $unidad         = trim($data['unidad'] ?? '');
@@ -64,6 +66,8 @@ try {
                 ancho_in=?,
                 altura_in=?,
                 peso_lb=?,
+                palets_restante=?,
+                cantidad_restante=?,
                 valor_unitario_restante=?,
                 valor_restante=?,
                 unidad_restante=?,
@@ -77,7 +81,7 @@ try {
         throw new Exception('Error en prepare: ' . $conexion->error);
     }
     $stmt->bind_param(
-        'ssssiisisssiiddsddddddsddddi',
+        'ssssiisisssiiddsddddiiddsddddi',
         $fechaEntrada,
         $fechaSalida,
         $recibo,
@@ -98,6 +102,8 @@ try {
         $anchoIn,
         $alturaIn,
         $pesoLb,
+        $paletsR,
+        $cantidadR,
         $valorUnitR,
         $valorR,
         $unidadR,

--- a/dist/api/warehouseusa/guardar_manual.php
+++ b/dist/api/warehouseusa/guardar_manual.php
@@ -18,10 +18,12 @@ try {
     $numeroCont   = trim($data['numero_contenedor'] ?? '');
     $ordenCompra  = trim($data['orden_compra'] ?? '');
     $palets       = trim($data['palets'] ?? '');
+    $paletsR      = trim($data['palets_restante'] ?? '');
     $numeroParte  = trim($data['numero_parte'] ?? '');
     $descripcion  = trim($data['descripcion'] ?? '');
     $modelo       = trim($data['modelo'] ?? '');
     $cantidad     = intval($data['cantidad'] ?? 0);
+    $cantidadR    = intval($data['cantidad_restante'] ?? 0);
     $valorUnit    = $data['valor_unitario'] === '' ? null : floatval(str_replace(',', '.', $data['valor_unitario']));
     $valor        = $data['valor'] === '' ? null : floatval(str_replace(',', '.', $data['valor']));
     $unidad       = trim($data['unidad'] ?? '');
@@ -64,6 +66,8 @@ try {
             ancho_in,
             altura_in,
             peso_lb,
+            palets_restante,
+            cantidad_restante,
             valor_unitario_restante,
             valor_restante,
             unidad_restante,
@@ -71,13 +75,13 @@ try {
             ancho_in_restante,
             altura_in_restante,
             peso_lb_restante
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
     );
     if (!$stmt) {
         throw new Exception('Error en prepare: ' . $conexion->error);
     }
     $stmt->bind_param(
-        'ssssiisisssiiddsddddddsdddd',
+        'ssssiisisssiiddsddddiiddsdddd',
         $fechaEntrada,
         $fechaSalida,
         $recibo,
@@ -98,6 +102,8 @@ try {
         $anchoIn,
         $alturaIn,
         $pesoLb,
+        $paletsR,
+        $cantidadR,
         $valorUnitR,
         $valorR,
         $unidadR,

--- a/dist/application/crearWarehouseUsa.php
+++ b/dist/application/crearWarehouseUsa.php
@@ -426,11 +426,11 @@ $user=$usuario->obtenerUsuarioPorId($IdUsuario);
         </div>
         <div class="col-md-4">
           <label class="form-label">Palets</label>
-          <input type="number" name="palets_extra" class="form-control">
+          <input type="number" name="palets_restante" class="form-control">
         </div>
         <div class="col-md-4">
           <label class="form-label">Cantidad de Cajas</label>
-          <input type="number" name="cantidad_extra" class="form-control">
+          <input type="number" name="cantidad_restante" class="form-control">
         </div>
         <div class="col-md-4">
           <label class="form-label">Valor Unitario</label>
@@ -645,6 +645,8 @@ document.addEventListener('DOMContentLoaded', () => {
       ancho:          form.ancho.value,
       altura:         form.altura.value,
       peso:           form.peso.value,
+      palets_restante:    form.palets_restante.value.trim(),
+      cantidad_restante: parseInt(form.cantidad_restante.value) || 0,
       valor_unitario_restante: form.valor_unitario_restante.value.trim(),
       valor_restante:          form.valor_restante.value.trim(),
       unidad_restante:         form.unidad_restante.value.trim(),
@@ -820,7 +822,7 @@ document.addEventListener('DOMContentLoaded', () => {
     extraBlock.style.display = diff > 0 ? 'block' : 'none';
     if (diff > 0) {
       // copia datos a los campos "_restante"
-      ['valor_unitario','valor','unidad','longitud','ancho','altura','peso']
+      ['palets','cantidad','valor_unitario','valor','unidad','longitud','ancho','altura','peso']
         .forEach(name => {
           form[`${name}_restante`].value = form[name].value;
         });

--- a/dist/application/detalleWarehouseUsa.php
+++ b/dist/application/detalleWarehouseUsa.php
@@ -382,7 +382,9 @@ $warehouse = $stmt->get_result()->fetch_assoc();
       </div>
 
 <?php
-  $hasRest = !empty($warehouse['valor_unitario_restante']) ||
+  $hasRest = !empty($warehouse['palets_restante']) ||
+             !empty($warehouse['cantidad_restante']) ||
+             !empty($warehouse['valor_unitario_restante']) ||
              !empty($warehouse['valor_restante']) ||
              !empty($warehouse['unidad_restante']) ||
              !empty($warehouse['longitud_in_restante']) ||
@@ -392,6 +394,18 @@ $warehouse = $stmt->get_result()->fetch_assoc();
   if ($hasRest): ?>
       <h5 class="mt-4">Datos Restantes</h5>
       <div class="row g-3">
+        <?php if (!empty($warehouse['palets_restante'])): ?>
+        <div class="col-md-4">
+          <label class="form-label">Palets Restante</label>
+          <div class="form-control bg-light"><?= htmlspecialchars($warehouse['palets_restante']) ?></div>
+        </div>
+        <?php endif; ?>
+        <?php if (!empty($warehouse['cantidad_restante'])): ?>
+        <div class="col-md-4">
+          <label class="form-label">Cajas Restantes</label>
+          <div class="form-control bg-light"><?= htmlspecialchars($warehouse['cantidad_restante']) ?></div>
+        </div>
+        <?php endif; ?>
         <?php if (!empty($warehouse['valor_unitario_restante'])): ?>
         <div class="col-md-4">
           <label class="form-label">Valor Unitario Restante</label>

--- a/dist/application/editarWarehouseUsa.php
+++ b/dist/application/editarWarehouseUsa.php
@@ -301,6 +301,18 @@ $warehouse = $stmt->get_result()->fetch_assoc();
       <div class="card-body">
 
         <div class="row g-3">
+          <?php if (!empty($warehouse['palets_restante'])): ?>
+          <div class="col-md-4">
+            <label class="form-label">Palets Restante</label>
+            <input type="number" name="palets_restante" class="form-control" value="<?= htmlspecialchars($warehouse['palets_restante']) ?>">
+          </div>
+          <?php endif; ?>
+          <?php if (!empty($warehouse['cantidad_restante'])): ?>
+          <div class="col-md-4">
+            <label class="form-label">Cajas Restantes</label>
+            <input type="number" name="cantidad_restante" class="form-control" value="<?= htmlspecialchars($warehouse['cantidad_restante']) ?>">
+          </div>
+          <?php endif; ?>
           <div class="col-md-4">
             <label class="form-label">Fecha Entrada</label>
             <input type="date" name="fecha_entrada" class="form-control" value="<?= htmlspecialchars($warehouse['fecha_entrada']) ?>">
@@ -384,7 +396,9 @@ $warehouse = $stmt->get_result()->fetch_assoc();
         </div>
 
 <?php
-  $hasRest = !empty($warehouse['valor_unitario_restante']) ||
+  $hasRest = !empty($warehouse['palets_restante']) ||
+             !empty($warehouse['cantidad_restante']) ||
+             !empty($warehouse['valor_unitario_restante']) ||
              !empty($warehouse['valor_restante']) ||
              !empty($warehouse['unidad_restante']) ||
              !empty($warehouse['longitud_in_restante']) ||
@@ -578,6 +592,8 @@ document.getElementById('editForm').addEventListener('submit', e => {
     ancho: form.ancho.value,
     altura: form.altura.value,
     peso: form.peso.value,
+    palets_restante: form.palets_restante?.value.trim() || '',
+    cantidad_restante: parseInt(form.cantidad_restante?.value) || 0,
     valor_unitario_restante: form.valor_unitario_restante?.value.trim() || '',
     valor_restante: form.valor_restante?.value.trim() || '',
     unidad_restante: form.unidad_restante?.value.trim() || '',

--- a/docs/add_restante_quantities.sql
+++ b/docs/add_restante_quantities.sql
@@ -1,0 +1,4 @@
+-- SQL script to store pallet and box counts for remaining products
+ALTER TABLE dispatch
+    ADD COLUMN palets_restante INT DEFAULT 0,
+    ADD COLUMN cantidad_restante INT DEFAULT 0;


### PR DESCRIPTION
## Summary
- store remaining pallet/box counts when creating/editing warehouse records
- display those values in detail and edit pages
- extend API endpoints to handle new columns
- add SQL helper script for the new columns

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68699cd946208326af86a1403d4d3c5c