### PR TITLE
Track remaining pallet and box counts

### DIFF
--- a/dist/api/warehouseusa/actualizar_manual.php
+++ b/dist/api/warehouseusa/actualizar_manual.php
@@ -37,6 +37,8 @@ try {
     $anchoR          = $data['ancho_restante'] === '' ? null : floatval(str_replace(',', '.', $data['ancho_restante']));
     $alturaR         = $data['altura_restante'] === '' ? null : floatval(str_replace(',', '.', $data['altura_restante']));
     $pesoR           = $data['peso_restante'] === '' ? null : floatval(str_replace(',', '.', $data['peso_restante']));
+    $paletsR         = trim($data['palets_restante'] ?? '');
+    $cantidadR       = intval($data['cantidad_restante'] ?? 0);
 
     if (!$id) {
         echo json_encode(['success' => false, 'message' => 'ID inválido']);
@@ -70,14 +72,16 @@ try {
                 longitud_in_restante=?,
                 ancho_in_restante=?,
                 altura_in_restante=?,
-                peso_lb_restante=?
+                peso_lb_restante=?,
+                palets_restante=?,
+                cantidad_restante=?
             WHERE id=?";
     $stmt = $conexion->prepare($sql);
     if (!$stmt) {
         throw new Exception('Error en prepare: ' . $conexion->error);
     }
     $stmt->bind_param(
-        'ssssiisisssiiddsddddddsddddi',
+        'ssssssssssssiddsddddddsddddisi',
         $fechaEntrada,
         $fechaSalida,
         $recibo,
@@ -105,6 +109,8 @@ try {
         $anchoR,
         $alturaR,
         $pesoR,
+        $paletsR,
+        $cantidadR,
         $id
     );
     $stmt->execute();

--- a/dist/api/warehouseusa/guardar_manual.php
+++ b/dist/api/warehouseusa/guardar_manual.php
@@ -36,6 +36,8 @@ try {
     $anchoR       = $data['ancho_restante'] === '' ? null : floatval(str_replace(',', '.', $data['ancho_restante']));
     $alturaR      = $data['altura_restante'] === '' ? null : floatval(str_replace(',', '.', $data['altura_restante']));
     $pesoR        = $data['peso_restante'] === '' ? null : floatval(str_replace(',', '.', $data['peso_restante']));
+    $paletsR      = trim($data['palets_restante'] ?? '');
+    $cantidadR    = intval($data['cantidad_restante'] ?? 0);
 
     if ($numeroFactura === '' || $fechaEntrada === '') {
         echo json_encode(['success' => false, 'message' => 'Datos incompletos']);
@@ -71,14 +73,16 @@ try {
             ancho_in_restante,
             altura_in_restante,
             peso_lb_restante,
+            palets_restante,
+            cantidad_restante,
             guardado_por
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
     );
     if (!$stmt) {
         throw new Exception('Error en prepare: ' . $conexion->error);
     }
     $stmt->bind_param(
-        'ssssiisisssiiddsddddddsdddds',
+        'ssssssssssssiddsddddddsddddsis',
         $fechaEntrada,
         $fechaSalida,
         $recibo,
@@ -106,6 +110,8 @@ try {
         $anchoR,
         $alturaR,
         $pesoR,
+        $paletsR,
+        $cantidadR,
         $guardadoPor
     );
     $stmt->execute();

--- a/dist/application/crearWarehouseUsa.php
+++ b/dist/application/crearWarehouseUsa.php
@@ -425,12 +425,12 @@ $user=$usuario->obtenerUsuarioPorId($IdUsuario);
           <input type="text" name="modelo_extra" class="form-control">
         </div>
         <div class="col-md-4">
-          <label class="form-label">Palets</label>
-          <input type="number" name="palets_extra" class="form-control">
+          <label class="form-label">Palets Restantes</label>
+          <input type="number" name="palets_restante" class="form-control">
         </div>
         <div class="col-md-4">
-          <label class="form-label">Cantidad de Cajas</label>
-          <input type="number" name="cantidad_extra" class="form-control">
+          <label class="form-label">Cantidad de Cajas Restantes</label>
+          <input type="number" name="cantidad_restante" class="form-control">
         </div>
         <div class="col-md-4">
           <label class="form-label">Valor Unitario</label>
@@ -645,6 +645,8 @@ document.addEventListener('DOMContentLoaded', () => {
       ancho:          form.ancho.value,
       altura:         form.altura.value,
       peso:           form.peso.value,
+      palets_restante:   form.palets_restante.value,
+      cantidad_restante: parseInt(form.cantidad_restante.value) || 0,
       valor_unitario_restante: form.valor_unitario_restante.value.trim(),
       valor_restante:          form.valor_restante.value.trim(),
       unidad_restante:         form.unidad_restante.value.trim(),
@@ -822,10 +824,12 @@ document.addEventListener('DOMContentLoaded', () => {
     extraBlock.style.display = diff > 0 ? 'block' : 'none';
     if (diff > 0) {
       // copia datos a los campos "_restante"
-      ['valor_unitario','valor','unidad','longitud','ancho','altura','peso']
+      ['valor_unitario','valor','unidad','longitud','ancho','altura','peso','palets','cantidad']
         .forEach(name => {
-          form[`${name}_restante`].value = form[name].value;
+          const target = form[`${name}_restante`];
+          if (target) target.value = form[name].value;
         });
+      form.cantidad_restante.value = diff;
     }
   }
 

--- a/dist/application/detalleWarehouseUsa.php
+++ b/dist/application/detalleWarehouseUsa.php
@@ -388,7 +388,9 @@ $warehouse = $stmt->get_result()->fetch_assoc();
              !empty($warehouse['longitud_in_restante']) ||
              !empty($warehouse['ancho_in_restante']) ||
              !empty($warehouse['altura_in_restante']) ||
-             !empty($warehouse['peso_lb_restante']);
+             !empty($warehouse['peso_lb_restante']) ||
+             !empty($warehouse['palets_restante']) ||
+             !empty($warehouse['cantidad_restante']);
   if ($hasRest): ?>
       <h5 class="mt-4">Datos Restantes</h5>
       <div class="row g-3">
@@ -432,6 +434,18 @@ $warehouse = $stmt->get_result()->fetch_assoc();
         <div class="col-md-4">
           <label class="form-label">Peso (lb) Restante</label>
           <div class="form-control bg-light"><?= htmlspecialchars($warehouse['peso_lb_restante']) ?></div>
+        </div>
+        <?php endif; ?>
+        <?php if (!empty($warehouse['palets_restante'])): ?>
+        <div class="col-md-4">
+          <label class="form-label">Palets Restantes</label>
+          <div class="form-control bg-light"><?= htmlspecialchars($warehouse['palets_restante']) ?></div>
+        </div>
+        <?php endif; ?>
+        <?php if (!empty($warehouse['cantidad_restante'])): ?>
+        <div class="col-md-4">
+          <label class="form-label">Cantidad de Cajas Restantes</label>
+          <div class="form-control bg-light"><?= htmlspecialchars($warehouse['cantidad_restante']) ?></div>
         </div>
         <?php endif; ?>
       </div>

--- a/dist/application/editarWarehouseUsa.php
+++ b/dist/application/editarWarehouseUsa.php
@@ -390,7 +390,9 @@ $warehouse = $stmt->get_result()->fetch_assoc();
              !empty($warehouse['longitud_in_restante']) ||
              !empty($warehouse['ancho_in_restante']) ||
              !empty($warehouse['altura_in_restante']) ||
-             !empty($warehouse['peso_lb_restante']);
+             !empty($warehouse['peso_lb_restante']) ||
+             !empty($warehouse['palets_restante']) ||
+             !empty($warehouse['cantidad_restante']);
   if ($hasRest): ?>
         <h5 class="mt-4">Datos Restantes</h5>
         <div class="row g-3">
@@ -434,6 +436,18 @@ $warehouse = $stmt->get_result()->fetch_assoc();
           <div class="col-md-4">
             <label class="form-label">Peso (lb) Restante</label>
             <input type="number" name="peso_restante" step="0.01" class="form-control" value="<?= htmlspecialchars($warehouse['peso_lb_restante']) ?>">
+          </div>
+          <?php endif; ?>
+          <?php if (!empty($warehouse['palets_restante'])): ?>
+          <div class="col-md-4">
+            <label class="form-label">Palets Restantes</label>
+            <input type="number" name="palets_restante" class="form-control" value="<?= htmlspecialchars($warehouse['palets_restante']) ?>">
+          </div>
+          <?php endif; ?>
+          <?php if (!empty($warehouse['cantidad_restante'])): ?>
+          <div class="col-md-4">
+            <label class="form-label">Cantidad de Cajas Restantes</label>
+            <input type="number" name="cantidad_restante" class="form-control" value="<?= htmlspecialchars($warehouse['cantidad_restante']) ?>">
           </div>
           <?php endif; ?>
         </div>
@@ -578,6 +592,8 @@ document.getElementById('editForm').addEventListener('submit', e => {
     ancho: form.ancho.value,
     altura: form.altura.value,
     peso: form.peso.value,
+    palets_restante: form.palets_restante?.value || '',
+    cantidad_restante: parseInt(form.cantidad_restante?.value) || 0,
     valor_unitario_restante: form.valor_unitario_restante?.value.trim() || '',
     valor_restante: form.valor_restante?.value.trim() || '',
     unidad_restante: form.unidad_restante?.value.trim() || '',

--- a/docs/add_restante_count_columns.sql
+++ b/docs/add_restante_count_columns.sql
@@ -1,0 +1,4 @@
+-- SQL script to add columns for remaining pallet and box counts
+ALTER TABLE dispatch
+    ADD COLUMN palets_restante INT DEFAULT 0,
+    ADD COLUMN cantidad_restante INT DEFAULT 0;


### PR DESCRIPTION
## Summary
- track pallets and boxes for remaining items
- expose those fields on create, edit and detail views
- update API endpoints to save new values
- document SQL for new table columns

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6869a1e3375883269a56eb39b4773f12